### PR TITLE
FUL-23090: Elaborate on testing instructions

### DIFF
--- a/home-screen-widget/profiles/README.md
+++ b/home-screen-widget/profiles/README.md
@@ -41,7 +41,7 @@ Next, you will have to register your new widget type with the Beekeeper API and 
 
 An access token can be obtained by following the steps to create a bot in the [help center](https://adminhelp.beekeeper.io/hc/en-us/articles/360002574420-Creating-Bots). Make sure to grant ``Admin Permissions``.
 
-For allowing access to your tenant, you will neeed to know your ``tenant_id``, which you can find my navigating to `https://<tenant_url>/api/2/config` and looking for the ``general.id`` field. 
+For allowing access to your tenant, you will neeed to know your ``tenant_id``, which you can find by navigating to `https://<tenant_url>/api/2/config` and looking for the ``general.id`` field. 
 
 To create a new widget type:
 

--- a/home-screen-widget/profiles/README.md
+++ b/home-screen-widget/profiles/README.md
@@ -61,11 +61,11 @@ The following four steps are **required** for every widget to be shown on the ho
  
 1. [Define Widget ID](src/components/Widget.vue#L19)
     ```javascript:title=home-screen-widget/profiles/src/components/Widget.vue
-    export const WIDGET_ID = 'profiles';
+    export const WIDGET_TYPE = 'profiles';
     ```
 2. [Register Widget Component](src/main.js#L9)
     ```javascript:title=home-screen-widget/profiles/src/main.js
-    BeekeeperHomeScreen.registerWidget(WIDGET_ID, component)
+    BeekeeperHomeScreen.registerWidget(WIDGET_TYPE, component)
     ```
 3. [Add widgetInstanceId Prop](src/components/Widget.vue#L38)
     ```javascript:title=home-screen-widget/profiles/src/components/Widget.vue

--- a/home-screen-widget/profiles/README.md
+++ b/home-screen-widget/profiles/README.md
@@ -41,6 +41,8 @@ Next, you will have to register your new widget type with the Beekeeper API and 
 
 An access token can be obtained by following the steps to create a bot in the [help center](https://adminhelp.beekeeper.io/hc/en-us/articles/360002574420-Creating-Bots). Make sure to grant ``Admin Permissions``.
 
+For allowing access to your tenant, you will neeed to know your ``tenant_id``, which you can find my navigating to `https://<tenant_url>/api/2/config` and looking for the ``general.id`` field. 
+
 To create a new widget type:
 
 ```shell

--- a/home-screen-widget/profiles/README.md
+++ b/home-screen-widget/profiles/README.md
@@ -27,7 +27,11 @@ Now, we can start the development server:
 yarn serve
 ```
 
-To use your widget in a test tenant, you will need to expose your development server to testing device. If both devices are in the same network, this should be simple. You should see the address of the development server on the console. Otherwise, we recommend to use a solution like [NGROK](https://ngrok.com/). You can start a simple forward with ``ngrok http 8080``. Next, you will need to make a request to the API to register the widget type and grant access for your tenant.
+To use your widget in a test tenant, you will need to expose your development server to testing device. If both devices are in the same network, this should be simple. You should see the address of the development server on the console. Otherwise, we recommend to use a solution like [NGROK](https://ngrok.com/).
+
+If you would like to test your widget in the browser, please follow the instructions in [@beekeeper/mobile-bridge-setup](https://www.npmjs.com/package/@beekeeper/mobile-bridge-setup) to setup a mobile-bridge mock.
+
+For more details, please visit the [Developer Portal](https://developers.beekeeper.io/v2/welcome/home-screen#2-widget-development).
 
 ## Registering with API
 

--- a/home-screen-widget/profiles/src/components/Widget.vue
+++ b/home-screen-widget/profiles/src/components/Widget.vue
@@ -16,20 +16,17 @@ import ProfilesGrid from '~/components/ProfilesGrid.vue';
 import store from '~/store';
 
 /**
- * Step 1: Define widget id
+ * Step 1: Specify widget type
  *
- *
- * This is the vue component of your widget that will be loaded onto the home screen.
  * In order for the home screen to be aware of the widget we need to register it. That's why we defined here
- * a unique widget string id that will identify our widget type in the Beekeeper ecosystem.
- * We called it 'profiles' since this is the profiles widget.
+ * a unique string as widget type. We called it 'profiles' since this is the profiles widget.
  * See also the "Widget type" in the "Configuration" section on the developers portal
  * {@link https://developers.beekeeper.io/v2/welcome/home-screen}
  */
-export const WIDGET_ID = 'profiles';
+export const WIDGET_TYPE = 'profiles';
 export const PROFILE_LIMIT = 50;
 
-const { mapState, mapActions } = createNamespacedHelpers(WIDGET_ID);
+const { mapState, mapActions } = createNamespacedHelpers(WIDGET_TYPE);
 
 
 export default {
@@ -89,7 +86,7 @@ export default {
          * When the module is registered, all of its getters, actions and mutations will be automatically
          * namespaced based on the path the module is registered at.
          */
-        this.$store.registerModule(WIDGET_ID, store, { preserveState: false });
+        this.$store.registerModule(WIDGET_TYPE, store, { preserveState: false });
     },
     created() {
         this.initStore(this.maxNumberOfDisplayedProfiles);

--- a/home-screen-widget/profiles/src/main.js
+++ b/home-screen-widget/profiles/src/main.js
@@ -1,5 +1,5 @@
 import BeekeeperHomeScreen from '@beekeeper/home-screen-sdk';
-import component, { WIDGET_ID } from '~/components/Widget.vue';
+import component, { WIDGET_TYPE } from '~/components/Widget.vue';
 
 /**
  * Step 2: Register widget component
@@ -7,4 +7,4 @@ import component, { WIDGET_ID } from '~/components/Widget.vue';
  * This is the entry point of your widget and here we need to register
  * the component with its widget id into the home screen
  */
-BeekeeperHomeScreen.registerWidget(WIDGET_ID, component);
+BeekeeperHomeScreen.registerWidget(WIDGET_TYPE, component);


### PR DESCRIPTION
I kept the ``tenant_id`` part and documented instead. I think it will be more align with the other calls, which also require a ``group_id`` and ``location_id``. What do you think?