### PR TITLE
FUL-37231: Added VueCompositionAPI plugin to the external dependecies

### DIFF
--- a/home-screen-widget/profiles/vue.config.js
+++ b/home-screen-widget/profiles/vue.config.js
@@ -10,13 +10,14 @@ module.exports = {
     },
     configureWebpack: {
         /**
-         * Vue and Vuex will be provided by the Home Screen through the window.
+         * Vue, Vuex, and Composition API plugin will be provided by the Home Screen through the window.
          * Please do not include these dependencies to prevent unexpected
          * behavior and increased bundle size.
          */
         externals: {
             vue: 'Vue',
             vuex: 'Vuex',
+            ['@vue/composition-api']: 'VueCompositionAPI',
         },
         output: {
             filename: 'js/[name].js',


### PR DESCRIPTION
### Description
In order to be able to use CompositionAPI in widgets we need to make sure that the plugin is provided by the home screen and not imported in the widget bundle.

### Solution
Add the plugin to the webpack external modules.